### PR TITLE
Add support Raspberry Pi Pico W, add channel_id begin, and fix invalid conversion

### DIFF
--- a/examples/bme280_weather/bme280_weather.ino
+++ b/examples/bme280_weather/bme280_weather.ino
@@ -11,7 +11,8 @@
 Discord_Webhook discord;
 // How to get the Webhook URL
 // https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks
-String DISCORD_WEBHOOK = "https://discord.com/api/webhooks/id/token";
+String channel_id = "123";
+String token = "123";
 
 Adafruit_BME280 bme;
 
@@ -23,7 +24,7 @@ void setup() {
     Serial.println("BME280 init failed");
   }
 
-  discord.begin(DISCORD_WEBHOOK); // Initialize the Discord_Webhook object
+  discord.begin(channel_id, token); // Initialize the Discord_Webhook object
   discord.addWiFi("WiFiName","WiFiPassword"); // Add WiFi credentials (you can add multiples WiFi SSID)
   discord.connectWiFi(); // Connect to WiFi
 }

--- a/examples/disableDebug/disableDebug.ino
+++ b/examples/disableDebug/disableDebug.ino
@@ -10,11 +10,13 @@
 Discord_Webhook discord;
 // How to get the Webhook URL
 // https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks
-String DISCORD_WEBHOOK = "https://discord.com/api/webhooks/id/token";
+String channel_id = "123";
+String token = "123";
+
 
 void setup() {
   Serial.begin(115200);
-  discord.begin(DISCORD_WEBHOOK); // Initialize the Discord_Webhook object
+  discord.begin(channel_id, token); // Initialize the Discord_Webhook object
   discord.disableDebug(); // Disable debug (no serial message will be send)
   discord.addWiFi("WiFiName","WiFiPassword"); // Add WiFi credentials (you can add multiples WiFi SSID)
   discord.connectWiFi(); // Connect to WiFi

--- a/examples/helloworld/helloworld.ino
+++ b/examples/helloworld/helloworld.ino
@@ -7,11 +7,12 @@
 Discord_Webhook discord; // Create a Discord_Webhook object
 // How to get the Webhook URL
 // https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks
-String DISCORD_WEBHOOK = "https://discord.com/api/webhooks/id/token";
+String channel_id = "123";
+String token = "123";
 
 void setup() {
   Serial.begin(115200);
-  discord.begin(DISCORD_WEBHOOK); // Initialize the Discord_Webhook object
+  discord.begin(channel_id, token); // Initialize the Discord_Webhook object
   discord.addWiFi("WiFiName","WiFiPassword"); // Add WiFi credentials (you can add multiples WiFi SSID)
   // discord.setTTS(true); // Add TTS
   discord.connectWiFi(); // Connect to WiFi

--- a/examples/timercam/timercam.ino
+++ b/examples/timercam/timercam.ino
@@ -39,7 +39,8 @@
 Discord_Webhook discord; // Create a Discord_Webhook object
 // How to get the Webhook URL
 // https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks
-String DISCORD_WEBHOOK = "https://discord.com/api/webhooks/id/token";
+String channel_id = "123";
+String token = "123";
 
 void setup()
 {
@@ -61,7 +62,7 @@ void setup()
     TimerCAM.Camera.sensor->set_saturation(TimerCAM.Camera.sensor, 3);
     TimerCAM.Camera.sensor->set_brightness(TimerCAM.Camera.sensor, -2);
 
-    discord.begin(DISCORD_WEBHOOK);              // Initialize the Discord_Webhook object
+    discord.begin(channel_id, token);              // Initialize the Discord_Webhook object
     discord.addWiFi("WiFiName", "WiFiPassword"); // Add WiFi credentials (you can add multiples WiFi SSID)
     // discord.setTTS(true); // Add TTS
     discord.connectWiFi(); // Connect to WiFi

--- a/examples/variable/variable.ino
+++ b/examples/variable/variable.ino
@@ -7,14 +7,15 @@
 Discord_Webhook discord;
 // How to get the Webhook URL
 // https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks
-String DISCORD_WEBHOOK = "https://discord.com/api/webhooks/id/token";
+String channel_id = "123";
+String token = "123";
 
 void setup() {
   int variable_int = 69; // Int variable (can be float, long etc...)
   String variable_string = "SUS"; // String variable
 
   Serial.begin(115200);
-  discord.begin(DISCORD_WEBHOOK); // Initialize the Discord_Webhook object
+  discord.begin(channel_id, token); // Initialize the Discord_Webhook object
   discord.addWiFi("WiFiName","WiFiPassword"); // Add WiFi credentials (you can add multiples WiFi SSID)
   discord.connectWiFi(); // Connect to WiFi
   discord.send("When the variable " + String(variable_int) + " is " + variable_string); // Send message

--- a/src/Discord_WebHook.cpp
+++ b/src/Discord_WebHook.cpp
@@ -28,7 +28,7 @@
 
 // Get webhook URL
 void Discord_Webhook::begin(String channel_id, String token) {
-  Discord_Webhook::webhook_url = "https://discord.com/api/webhooks/" + channel_id + "/" + token;
+  Discord_Webhook::webhook_url = "https://discordapp.com/api/webhooks/" + channel_id + "/" + token;
 }
 
 // Add WiFi credentials

--- a/src/Discord_WebHook.cpp
+++ b/src/Discord_WebHook.cpp
@@ -27,8 +27,8 @@
 #include "Discord_WebHook.h"
 
 // Get webhook URL
-void Discord_Webhook::begin(String webhook_url) {
-  Discord_Webhook::webhook_url = webhook_url;
+void Discord_Webhook::begin(String channel_id, String token) {
+  Discord_Webhook::webhook_url = "https://discord.com/api/webhooks/" + channel_id + "/" + token;;
 }
 
 // Add WiFi credentials

--- a/src/Discord_WebHook.cpp
+++ b/src/Discord_WebHook.cpp
@@ -28,7 +28,7 @@
 
 // Get webhook URL
 void Discord_Webhook::begin(String channel_id, String token) {
-  Discord_Webhook::webhook_url = "https://discord.com/api/webhooks/" + channel_id + "/" + token;;
+  Discord_Webhook::webhook_url = "https://discord.com/api/webhooks/" + channel_id + "/" + token;
 }
 
 // Add WiFi credentials

--- a/src/Discord_WebHook.cpp
+++ b/src/Discord_WebHook.cpp
@@ -1,70 +1,79 @@
 /*
- *  Discord_WebHook.cpp
- *  Library for sending messages to Discord via WebHook
- *
- *  Copyright (c) 2024 µsini
- *  Author : Rémi Sarrailh
- *  Version : 2.0.0
- *
- *  The MIT License (MIT)
- *    Permission is hereby granted, free of charge, to any person obtaining a copy
- *    of this software and associated documentation files (the "Software"), to
- *  deal in the Software without restriction, including without limitation the
- *  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
- *  sell copies of the Software, and to permit persons to whom the Software is
- *    furnished to do so, subject to the following conditions:
- *    The above copyright notice and this permission notice shall be included in
- *    all copies or substantial portions of the Software.
- *    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- *    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- *    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- *    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- *    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
- *  IN THE SOFTWARE.
- */
+  Discord_WebHook.cpp
+  Library for sending messages to Discord via WebHook
+
+  Copyright (c) 2024 µsini
+  Author : Rémi Sarrailh
+  Version : 2.0.0
+
+  The MIT License (MIT)
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+*/
 
 #include "Discord_WebHook.h"
 
-
-// Get webhook url into webhook_url
-void Discord_Webhook::begin(String webhook_url)
-{
+// Get webhook URL
+void Discord_Webhook::begin(String webhook_url) {
   Discord_Webhook::webhook_url = webhook_url;
 }
 
-// Add WiFi credentials using WiFiMulti
-void Discord_Webhook::addWiFi(const char *ssid, const char *password)
-{
-  if (Discord_Webhook::debug)
-  {
-    Serial.print("[WIFI] Added ssid:");
-    Serial.println(ssid);
-  }
-  Discord_Webhook::wifi.addAP(ssid, password);
+// Add WiFi credentials
+void Discord_Webhook::addWiFi(const char* ssid, const char* password) {
+  #if defined(ESP32) || defined(ESP8266)
+    if (Discord_Webhook::debug) {
+      Serial.print("[WIFI] Added ssid: ");
+      Serial.println(ssid);
+    }
+    wifi.addAP(ssid, password);
+  #elif defined(ARDUINO_ARCH_RP2040) // Experimental For Raspberry Pi Pico W
+    WiFi.begin(ssid, password);
+  #endif
 }
 
-// Wait for WiFi connection to established
-void Discord_Webhook::connectWiFi()
-{
-  WiFi.mode(WIFI_STA);
-  if (Discord_Webhook::debug)
-  {
-    Serial.println("[WiFi] Connecting WiFi");
-  }
-  // wait for WiFi connection
-  while ((Discord_Webhook::wifi.run() != WL_CONNECTED))
-  {
-    if (Discord_Webhook::debug)
-    {
-      Serial.print(".");
+// Connect to WiFi
+void Discord_Webhook::connectWiFi() {
+  #if defined(ESP32) || defined(ESP8266)
+    WiFi.mode(WIFI_STA);
+    if (Discord_Webhook::debug) {
+      Serial.println("[WiFi] Connecting WiFi");
     }
-    delay(100);
-  }
-  if (Discord_Webhook::debug)
-  {
-    Serial.println("[WiFi] Connected");
-  }
+    while (wifi.run() != WL_CONNECTED) {
+      delay(100);
+      if (Discord_Webhook::debug) {
+        Serial.print(".");
+      }
+    }
+    if (Discord_Webhook::debug) {
+      Serial.println("[WiFi] Connected");
+    }
+  #elif defined(ARDUINO_ARCH_RP2040) // Experimental For Raspberry Pi Pico W
+    if (Discord_Webhook::debug) {
+      Serial.println("[WiFi] Connecting WiFi");
+    }
+    while (WiFi.status() != WL_CONNECTED) {
+      delay(100);
+      if (Discord_Webhook::debug) {
+        Serial.print(".");
+      }
+    }
+    if (Discord_Webhook::debug) {
+      Serial.println("[WiFi] Connected");
+    }
+  #endif
 }
 
 // Set TTS variable
@@ -94,48 +103,39 @@ bool Discord_Webhook::sendFile(uint8_t *fileData, size_t fileLength, const Strin
 
     String bodyEnd = "\r\n--" + boundary + "--\r\n";
 
-    int contentLength = bodyStart.length() + fileLength + bodyEnd.length();
-
     if (Discord_Webhook::debug)
     {
       Serial.println("[HTTP] Connecting to Discord...");
-      Serial.println("[HTTP] Content-Length: " + String(contentLength));
+      Serial.println("[HTTP] File Upload Start");
     }
 
     // Begin HTTPS requests
     if (https.begin(*client, Discord_Webhook::webhook_url))
     {
       https.addHeader("Content-Type", "multipart/form-data; boundary=" + boundary);
-      https.addHeader("Content-Length", String(contentLength));
 
-      // Create the full body
-      String body = bodyStart;
-      body += String((char *)fileData, fileLength);
-      body += bodyEnd;
-
-      // Send POST request
-      int httpCode = https.POST((uint8_t *)body.c_str(), body.length());
-      if (httpCode > 0)
+      // Send POST request in chunks
+      https.collectHeaders(nullptr, 0); // Ensure no automatic content collection
+      if (https.POST((uint8_t *)bodyStart.c_str(), bodyStart.length()) == HTTP_CODE_OK)
       {
+        // Write binary file data directly
+        client->write(fileData, fileLength); 
+
+        // Write the body end
+        client->write((uint8_t *)bodyEnd.c_str(), bodyEnd.length());
+
         if (Discord_Webhook::debug)
         {
-          Serial.printf("[HTTP] POST... code: %d\n", httpCode);
-          if (httpCode == HTTP_CODE_OK)
-          {
-            Serial.println("[HTTP] POST... success");
-            ok = true;
-          }
-          else
-          {
-            Serial.printf("[HTTP] ERROR: %s\n", https.getString().c_str());
-          }
+          Serial.println("[HTTP] File Upload Complete");
         }
+
+        ok = true;
       }
       else
       {
         if (Discord_Webhook::debug)
         {
-          Serial.printf("[HTTP] POST... failed, error: %s\n", https.errorToString(httpCode).c_str());
+          Serial.println("[HTTP] POST Error");
         }
       }
       https.end();

--- a/src/Discord_WebHook.h
+++ b/src/Discord_WebHook.h
@@ -53,7 +53,7 @@
 
 class Discord_Webhook {
 public:
-  void begin(String webhook_url);
+  void begin(String channel_id, String token);
   void addWiFi(const char* ssid, const char* password);
   void connectWiFi();
   void disableDebug();

--- a/src/Discord_WebHook.h
+++ b/src/Discord_WebHook.h
@@ -29,7 +29,7 @@
 
 #include <Arduino.h>
 
-// Define if it is an ESP32 (code should works on new board ESP32-S2/ESP32-C3)
+// Define platform-specific dependencies
 #if defined(ESP32)
 #include <WiFi.h>
 #include <WiFiMulti.h>
@@ -41,16 +41,14 @@
 #include <ESP8266WiFiMulti.h>
 #include <ESP8266HTTPClient.h>
 #include <WiFiClientSecure.h>
-//#include "WiFiClientSecureAxTLS.h"
-#include <ESP8266HTTPClient.h>
-#else
-// We still open it as ESP32 for compatibility with later version (not tested)
-#warning "Library worked on ESP8266/ESP32 only"
-#warning "Compilation pour une carte non supportée"
+
+#elif defined(ARDUINO_ARCH_RP2040) // Experimental For Raspberry Pi Pico W
 #include <WiFi.h>
-#include <WiFiMulti.h>
+#include <WiFiClientSecure.h>
 #include <HTTPClient.h>
 
+#else
+#error "This library supports ESP32, ESP8266, and Raspberry Pi Pico W only."
 #endif
 
 class Discord_Webhook {
@@ -67,12 +65,18 @@ public:
 
 private:
   bool sendRequest(String jsonPayload);
+
+#if defined(ESP32) || defined(ESP8266)
   #ifdef ESP32
     WiFiMulti wifi;
   #endif
   #ifdef ESP8266
     ESP8266WiFiMulti wifi;
   #endif
+#elif defined(ARDUINO_ARCH_RP2040)
+  // No multi-AP feature yet for RP2040
+#endif
+
   String webhook_url;
   bool tts = false;
   bool debug = true;


### PR DESCRIPTION
Adding support:
+ [Experimental] Add Support Raspberry Pi Pico W
+ support `discord.begin(channel_id, token);`

Fix :
```
Discord_WebHook.cpp:122:22: error: invalid conversion from 'char*' to 'long int' [-fpermissive]
  122 |       body += String((char *)fileData, fileLength);
      |                      ^~~~~~~~~~~~~~~~
      |                      |
      |                      char*
```